### PR TITLE
Switch build from SQLite to DuckDB for penguins DB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ ${DB}/contact_tracing.db: bin/create_contacts.py
 ${DB}/lab_log.db: bin/create_lab_log.py
 	python $< $@
 
-${DB}/penguins.db : bin/create_penguins.py misc/penguins.csv
+${DB}/penguins.db : bin/create_penguins_duckdb.py misc/penguins.csv
+	@mkdir -p ${DB}
 	python $< $@ misc/penguins.csv
 
 ## psql_db: create PostgreSQL penguins database

--- a/bin/create_penguins_duckdb.py
+++ b/bin/create_penguins_duckdb.py
@@ -1,0 +1,88 @@
+"""Create penguins database in DuckDB, including randomized little penguins.
+
+This mirrors the behavior of bin/create_penguins.py (SQLite) but writes
+DuckDB format and uses the DuckDB Python API.
+"""
+
+import csv
+import random
+import sys
+
+import duckdb
+
+SEED = 571289354
+LITTLE_SIZE = 10
+
+CREATE = """\
+drop table if exists penguins;
+create table penguins (
+    species text,
+    island text,
+    bill_length_mm double,
+    bill_depth_mm double,
+    flipper_length_mm double,
+    body_mass_g double,
+    sex text
+);
+
+drop table if exists little_penguins;
+create table little_penguins (
+    species text,
+    island text,
+    bill_length_mm double,
+    bill_depth_mm double,
+    flipper_length_mm double,
+    body_mass_g double,
+    sex text
+);
+"""
+
+
+def _float(x):
+    return None if x == "" else float(x)
+
+
+def _text(x):
+    return None if x == "" else x
+
+
+FIELDS = [_text, _text, _float, _float, _float, _float, _text]
+
+
+def main():
+    """Main driver."""
+    db_name = sys.argv[1]
+    csv_name = sys.argv[2]
+
+    conn = duckdb.connect(db_name)
+
+    # DuckDB Python execute supports multiple statements separated by ';'
+    conn.execute(CREATE)
+
+    # Read and coerce CSV rows like the original script
+    with open(csv_name, newline="", encoding="utf-8") as fh:
+        reader = csv.reader(fh)
+        rows = []
+        for i, row in enumerate(reader):
+            if i == 0:
+                # header
+                assert len(row) == len(FIELDS)
+                continue
+            assert len(row) == len(FIELDS)
+            rows.append([f(val) for f, val in zip(FIELDS, row)])
+
+    # Insert full dataset
+    spots = ", ".join(["?"] * len(FIELDS))
+    conn.executemany(f"insert into penguins values ({spots});", rows)
+
+    # Create deterministic sample of LITTLE_SIZE rows for little_penguins
+    random.seed(SEED)
+    sample = random.sample(rows, LITTLE_SIZE)
+    conn.executemany(f"insert into little_penguins values ({spots});", sample)
+
+    conn.commit()
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/common.mk
+++ b/common.mk
@@ -15,24 +15,24 @@ clean:
 	@find . -type d -name .pytest_cache | xargs rm -r
 	@find . -type d -name .ruff_cache | xargs rm -r
 
-SQLITE := sqlite3
+DUCKDB := duckdb
 
 # Get the path to this file from wherever it is included.
 # See https://stackoverflow.com/questions/18136918/how-to-get-current-relative-directory-of-your-makefile
 ROOT := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
 
 MODE := ${ROOT}/misc/mode.txt
-MEMORY := ${SQLITE} :memory:
+MEMORY := ${DUCKDB} :memory:
 
 DB := ${ROOT}/db
-ASSAYS := ${SQLITE} ${DB}/assays.db
-CONTACTS := ${SQLITE} ${DB}/contact_tracing.db
-LAB_LOG := ${SQLITE} ${DB}/lab_log.db
-PENGUINS := ${SQLITE} ${DB}/penguins.db
+ASSAYS := ${DUCKDB} ${DB}/assays.db
+CONTACTS := ${DUCKDB} ${DB}/contact_tracing.db
+LAB_LOG := ${DUCKDB} ${DB}/lab_log.db
+PENGUINS := ${DUCKDB} ${DB}/penguins.db
 
-ASSAYS_TMP := ${SQLITE} /tmp/assays.db
-CONTACTS_TMP := ${SQLITE} /tmp/contact_tracing.db
-PENGUINS_TMP := ${SQLITE} /tmp/penguins.db
+ASSAYS_TMP := ${DUCKDB} /tmp/assays.db
+CONTACTS_TMP := ${DUCKDB} /tmp/contact_tracing.db
+PENGUINS_TMP := ${DUCKDB} /tmp/penguins.db
 
 %.assays.out: %.assays.sql
 	cat ${MODE} $< | ${ASSAYS} > $@

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.3.0"
 requires-python = ">=3.12"
 dependencies = [
     "adbc-driver-sqlite",
+    "duckdb",
     "click",
     "faker",
     "jupysql",


### PR DESCRIPTION
1. Replace sqlite3 CLI with duckdb in common.mk for in-repo query targets. 
2. Add create_penguins_duckdb.py to generate DuckDB-format db/penguins.db.
3. command in ./Makefile that generates db/penguins.db